### PR TITLE
feat: Create Moodle MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MOODLE_DOMAIN=your_moodle_domain
+MOODLE_TOKEN=your_moodle_token

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,51 @@
+import sys
+import json
+from MoodleAPI import MoodleAPI
+
+def main():
+    moodle_api = MoodleAPI(domain=None, token=None)  # Will be loaded from .env
+
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+
+        try:
+            request = json.loads(line)
+            method_name = request.get("method")
+            params = request.get("params", {})
+            request_id = request.get("id")
+
+            if not method_name or not hasattr(moodle_api, method_name):
+                response = {
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32601, "message": "Method not found"},
+                    "id": request_id,
+                }
+            else:
+                method = getattr(moodle_api, method_name)
+                try:
+                    result = method(**params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "result": result,
+                        "id": request_id,
+                    }
+                except Exception as e:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32603, "message": str(e)},
+                        "id": request_id,
+                    }
+        except json.JSONDecodeError:
+            response = {
+                "jsonrpc": "2.0",
+                "error": {"code": -32700, "message": "Parse error"},
+                "id": None,
+            }
+
+        sys.stdout.write(json.dumps(response) + "\\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+python-dotenv
+json-rpc


### PR DESCRIPTION
This commit introduces a Moodle MCP (Model Context Protocol) server that communicates over stdio using JSON-RPC.

The server provides access to the Moodle API functions defined in `MoodleAPI.py`.

Key changes:
- Added `mcp_server.py`: The main server script that handles JSON-RPC requests and responses.
- Added `requirements.txt`: Specifies the Python dependencies (`requests`, `python-dotenv`, `json-rpc`).
- Added `.env.example`: A template for the required environment variables (`MOODLE_DOMAIN`, `MOODLE_TOKEN`).